### PR TITLE
neon egg rift

### DIFF
--- a/src/data/eggs.json
+++ b/src/data/eggs.json
@@ -276,7 +276,7 @@
     ],
     "luckIgnored": false,
     "infinityEgg": "Minigame Paradise",
-    "canSpawnAsRift": false,
+    "canSpawnAsRift": true,
     "secretBountyRotation": true,
     "dateAdded": "2025-05-17",
     "dateRemoved": "",


### PR DESCRIPTION
Neon egg can spawn as a rift now, but it was set to false so fixed that 